### PR TITLE
Got rid of 'Term' Search

### DIFF
--- a/TextSearchApp.Host/Service/TextSearchAppService.cs
+++ b/TextSearchApp.Host/Service/TextSearchAppService.cs
@@ -45,7 +45,8 @@ public class TextSearchAppService : ITextSearchAppService
             .From(0)
             .Size(20)
             .Query(q => q
-                .Term(t => t.Text, text)
+                .Match(m => m.Field(f => f.Text)
+                    .Query(text))
             )
         );
 


### PR DESCRIPTION
Got rid of 'Term' Search, [see there](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html#:~:text=Avoid%20using%20the%20term%20query%20for%20text%20fields)